### PR TITLE
Compound Object Docs

### DIFF
--- a/docs/metadata/compound-objects.md
+++ b/docs/metadata/compound-objects.md
@@ -5,43 +5,37 @@ nav_order: 8
 ---
 # Compound Objects and Multiples
 
-_Note: While "object" is in the title of this section, a "compound object" is better categorized as an concept related to metadata than to objects (i.e. digital files) proper._
-
-Compound objects and multiples can be used in both CollectionBuilder-CSV and CollectionBuilder-GH, but the implementation process is slightly different between the two templates.
-
-Please see the demo compound object metadata sheets for [CollectionBuilder-CSV](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) and [CollectionBuilder-GH](https://docs.google.com/spreadsheets/d/1C1ZV3VrawKRLYUtemUdi8hLbhJw2yhn6kv-xv6_HaNk/copy?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) and [demo CollectionBuilder-GH site](https://collectionbuilder.github.io/collectionbuilder-gh/) to see how this looks in operation.  
-
-## Context
-
 A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one connected item in the collection site and displayed on a single Item page. 
 
-CollectionBuilder has two default types of compound object displays: 
-"compound_object" and "multiple".
+Please visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) and [demo CollectionBuilder-GH site](https://collectionbuilder.github.io/collectionbuilder-gh/) for examples of compound objects in action, and view the demo compound object metadata sheets for [CollectionBuilder-CSV](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) and [CollectionBuilder-GH](https://docs.google.com/spreadsheets/d/1C1ZV3VrawKRLYUtemUdi8hLbhJw2yhn6kv-xv6_HaNk/copy?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet.  
 
-In CollectionBuilder-CSV, these values (`compound_object` and `multiple`) populate the compound object record's display_template field. In CollectionBuilder-GH, they populate the compound object record's format field.
+CollectionBuilder has two built in types of compound object displays: "compound_object" and "multiple".
 
-### compound_object 
+Compound objects and multiples can be used in both CollectionBuilder-CSV and CollectionBuilder-GH, but the implementation process is slightly different between the two templates.
+In CollectionBuilder-CSV, these values (`compound_object` and `multiple`) populate the compound object record's "display_template" field. In CollectionBuilder-GH, they populate the compound object record's "format" field.
+
+## compound_object 
 
 A "compound_object" item can include a set of objects with any media type that CollectionBuilder handles, i.e. image, pdf, video, audio, panorama (CB-CSV only), or record.
 
-- Parent items with the display_template (CB-CSV) or format (CB-GH) value of `compound_object` will generate an Item page featuring a grid of cards representing item thumbnails for each child object. Clicking the child thumbnails opens a child object page as a modal. The child modal has similar features to the display of a single item page, but maintains the context of the compound object parent. 
-- "compound_object" examples:
+- Parent items with the display_template (CB-CSV) or format (CB-GH) value of `compound_object` will generate an Item page featuring a grid of cards representing item thumbnails for each child object. Clicking the child thumbnails opens a child object page as a modal. The child modal has similar features to the display of an individual item page, but maintains the context of the compound object parent. 
+- "compound_object" use case examples:
     - **Scrapbook**: to represent a digitized scrapbook, a compound object might contain a series of 25 pages or photographs from a scrapbook. The parent compound object metadata record provides full details about the scrapbook, while the child object metadata records will only describe the unique information about each individual page or photo. 
     - **Oral history**: an oral history compound object might contain various derivatives of an interview, such as audio, video, transcript, and portrait.
     - **Gallery**: a gallery compound object might contain a series of images from one event that are individually described with independent metadata.
 
-### multiple
+## multiple
 
-A "multiple" item is image-based, and is best used for items such as postcards or multi-view records of a 3-dimensional artifact. 
+A "multiple" item is a set of images to be displayed together in a single Item page. 
 
-- Parent items with the display_template value (CB-CSV) or format (CB-GH) of `multiple` will generate an Item page featuring the child objects displayed as a vertical series of large images that scroll down the page. The children *do not* have individual child object pages/modals. Instead, clicking the child images will open a spotlight gallery of the images.
-- "multiple" Examples: 
+- Parent items with the display_template value (CB-CSV) or format (CB-GH) of `multiple` will generate an Item page featuring the child objects displayed as a vertical series of large images that scroll down the page. The children *do not* have individual child object pages/modals. Instead, clicking the child images will open a spotlight gallery of the images. Individual metadata for each child object is *not* displayed.
+- "multiple" use case examples: 
     - **Postcard**: images of a postcard's front and back that are not individually described in the metadata beyond having a "title" value. 
-    - **3D archeological artifact**: images representing standardized perspectives of an archeological artifact that are not individually described in the metadata beyond having a "title" value.
+    - **3D archeological artifact**: images representing standardized perspectives of an archeological artifact that are not individually described in the metadata beyond having a "title" value (for example, "top", "bottom", "side" of a bowl).
     - **Gallery**: images from a single event that are not individually described in the metadata beyond having a "title" value.
 
 {:.alert .alert-blue }
-The "multiple" display_template (CB-CSV) or format (CB-GH) works well if the child files do *not* require their own extensive metadata. By default, only the "title" of the child files will be represented on the item page -- all other metadata for child files will be ignored. 
+The "multiple" display_template (CB-CSV) or format (CB-GH) works well if the child files do *not* require their own metadata. By default, only the "title" of the child files will be represented on the item page -- all other metadata for child files will be ignored. 
 
 ## Compound Object Metadata Approach Using "parentid"
 
@@ -49,9 +43,10 @@ Incorporating compound objects requires some additional conventions in your meta
 
 For non-compound object collection items, each object is represented by one row in your metadata spreadsheet.
 Compound objects are different in that they are represented by multiple rows in the metadata: a parent row plus one or more child rows.
-The parent row describes the compound object as a whole, while each child row describes an individual child object within the compound object.
+The parent row describes the compound object Item as a whole, while each child row describes an individual child object within the compound object.
 The children are connected to the parent through the "parentid" field, which contains a value matching the parent's "objectid" value.
-Ultimately all of the children will be displayed together on a single Item page.
+
+Ultimately all of the related children rows will be displayed together on a single Item page.
 
 This approach allows each child object to be fully described individually (or not) using any field in your metadata.
 It is also useful if you are exporting existing metadata from a platform such as CONTENTdm with "page level" metadata.
@@ -60,15 +55,17 @@ It is also useful if you are exporting existing metadata from a platform such as
 
 To include compound objects using the "compound_object" or "multiple" display_template (CB-CSV) or format (CB-GH), the following additional conventions are used in your metadata spreadsheet:
 
-- A "parentid" field must be added to your metadata spreadsheet. For non-compound object items, and parent items, the "parentid" field will be left blank.
+- Add a "parentid" field to your metadata spreadsheet. For non-compound object items, and parent items, the "parentid" field will be left blank.
 - The parent metadata record for each compound object will have an objectid (but no parentid), and use the display_template (CB-CSV) or format (CB-GH) value of either `compound_object` or `multiple`.  
 - Each child record **must have an objectid AND a parentid**
     - Each child record's "parentid" value must match the parent metadata record's `objectid`. (e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.)
     - Each child record should have a value for display_template (CB-CSV) or format (CB-GH) that corresponds to its media type. See [options for display_template]({{ '/docs/metadata/csv_metadata/#display_template' | relative_url }}) for CB-CSV and [options for format]({{ '/docs/metadata/gh_metadata/#format' | relative_url }}) for CB-GH. A parent with display_template/format `multiple` will have children with display_template (CB-CSV) value `image` or format (CB-GH) value `image/jpeg`. A parent with display_template/format `compound_object` could have children with a variety of display_template (CB-CSV) or format (CB-GH) values.
+    - Remember, as will all other rows in your metadata, each child `objectid` must still be unique in the collection!
 
-**For CollectionBuilder-CSV only**: The image listed in "image_thumb" and "image_small" of the parent will be used to represent the item in all visualizations.
+For CollectionBuilder-CSV, the image listed in "image_thumb" and "image_small" of the parent will be used to represent the compound object in all visualizations.
+In CollectionBuilder-GH, compound objects will be represented by icons in visualizations.
 
-### Visualization Configuration Options
+## Visualization Configuration Options
 
 Configure the "Compound Objects" options in "theme.yml" to add or remove the children of your compound objects on the map, timeline, data, carousel, browse, and search pages.
 

--- a/docs/metadata/compound-objects.md
+++ b/docs/metadata/compound-objects.md
@@ -5,60 +5,73 @@ nav_order: 8
 ---
 # Compound Objects and Multiples
 
-_Note: While "object" is in the title of this section, a "compound object" is better categorized as an issue related to metadata than to objects (i.e. digital files) proper._
+_Note: While "object" is in the title of this section, a "compound object" is better categorized as an concept related to metadata than to objects (i.e. digital files) proper._
 
-Compound objects and multiples can be used in both CollectionBuilder-CSV and CollectionBuilder-GH, but the implementation process is slightly different between the two templates. 
+Compound objects and multiples can be used in both CollectionBuilder-CSV and CollectionBuilder-GH, but the implementation process is slightly different between the two templates.
 
-Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) to see how this looks in operation. 
+Please see the demo compound object metadata sheets for [CollectionBuilder-CSV](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) and [CollectionBuilder-GH](https://docs.google.com/spreadsheets/d/1C1ZV3VrawKRLYUtemUdi8hLbhJw2yhn6kv-xv6_HaNk/copy?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) and [demo CollectionBuilder-GH site](https://collectionbuilder.github.io/collectionbuilder-gh/) to see how this looks in operation.  
 
 ## Context
 
-A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one singular connected object in the system and displayed on a single "item" page. 
+A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one connected item in the collection site and displayed on a single Item page. 
 
-CollectionBuilder has two default types of compound object display templates: 
+CollectionBuilder has two default types of compound object displays: 
 "compound_object" and "multiple".
+
+In CollectionBuilder-CSV, these values (`compound_object` and `multiple`) populate the compound object record's display_template field. In CollectionBuilder-GH, they populate the compound object record's format field.
 
 ### compound_object 
 
-A `compound_object` can include a set of objects from any type of media that CollectionBuilder handles, i.e. image, pdf, video, audio, panorama, or record, matching the single item display_template options. 
+A "compound_object" item can include a set of objects with any media type that CollectionBuilder handles, i.e. image, pdf, video, audio, panorama (CB-CSV only), or record.
 
-- Parent items with the display_template value of `compound_object` will generate an Item page featuring a grid of cards representing item thumbnails for each child object. Clicking the child thumbnails opens a child object page as a modal. The child modal has similar features to the display of a single item page, but maintains the context of the compound object parent. 
-- `compound_object` examples:
-    - **Scrapbook**: for a digitized scrapbook the "compound object" might contain a series of 25 individual page images or 25 individual items listed on multiple pages. The parent metadata record provides full details about the scrapbook, while the child metadata records will only describe the unique information about each page or item. 
-    - **Oral history**: each object might contain different derivatives of an interview, audio, video, transcript, and portrait.
-    - **Gallery**: a gallery of images from one event that are individually described with independent metadata.
+- Parent items with the display_template (CB-CSV) or format (CB-GH) value of `compound_object` will generate an Item page featuring a grid of cards representing item thumbnails for each child object. Clicking the child thumbnails opens a child object page as a modal. The child modal has similar features to the display of a single item page, but maintains the context of the compound object parent. 
+- "compound_object" examples:
+    - **Scrapbook**: to represent a digitized scrapbook, a compound object might contain a series of 25 pages or photographs from a scrapbook. The parent compound object metadata record provides full details about the scrapbook, while the child object metadata records will only describe the unique information about each individual page or photo. 
+    - **Oral history**: an oral history compound object might contain various derivatives of an interview, such as audio, video, transcript, and portrait.
+    - **Gallery**: a gallery compound object might contain a series of images from one event that are individually described with independent metadata.
 
 ### multiple
 
-A `multiple` is image-based, and is best used for items such as postcards or multi-view records of a 3-dimensional object. 
+A "multiple" item is image-based, and is best used for items such as postcards or multi-view records of a 3-dimensional artifact. 
 
-- Parent items with the display_template value of `multiple` will generate an Item page featuring the child items displayed as larger images. The children *do not* have child object pages / modals. Instead, clicking the child images will open a zoomable spotlight gallery of the images.
-- `multiple` Examples: 
-    - **Postcard**: a compound object containing a front and back image. 
-    - **3D archeological artifact**: archeological objects are often imaged from standardized perspectives to provide experts information about the piece.
-    - **Gallery**: a gallery of images from one event that are not individually described.
+- Parent items with the display_template value (CB-CSV) or format (CB-GH) of `multiple` will generate an Item page featuring the child objects displayed as a vertical series of large images that scroll down the page. The children *do not* have individual child object pages/modals. Instead, clicking the child images will open a spotlight gallery of the images.
+- "multiple" Examples: 
+    - **Postcard**: images of a postcard's front and back that are not individually described in the metadata beyond having a "title" value. 
+    - **3D archeological artifact**: images representing standardized perspectives of an archeological artifact that are not individually described in the metadata beyond having a "title" value.
+    - **Gallery**: images from a single event that are not individually described in the metadata beyond having a "title" value.
 
 {:.alert .alert-blue }
-The "multiple" display template works well if the additional files do *not* require their own extensive metadata. By default, only the "title" of the child elements will be represented on the item page -- all other metadata for child objects will be ignored. 
+The "multiple" display_template (CB-CSV) or format (CB-GH) works well if the child files do *not* require their own extensive metadata. By default, only the "title" of the child files will be represented on the item page -- all other metadata for child files will be ignored. 
 
-## Our Metadata Approach Using "parentid"
+## Compound Object Metadata Approach Using "parentid"
 
-Using these templates requires some additional conventions to represent your compound objects in your metadata spreadsheet.
-Our approach for describing "compound objects" and "multiples" requires a top level metadata record describing the object overall, the parent, along with one or more individual child records describing the files related to the parent. 
-The children are connected to the parent by using the "parentid" field, whose value matches the parent's "objectid" value.
+Incorporating compound objects requires some additional conventions in your metadata spreadsheet.
 
-This allows each child object to be fully described individually (or not) using your full metadata template. It is also useful if you are exporting existing metadata from a platform such as CONTENTdm with "page level" metadata.
+For non-compound object collection items, each object is represented by one row in your metadata spreadsheet.
+Compound objects are different in that they are represented by multiple rows in the metadata: a parent row plus one or more child rows.
+The parent row describes the compound object as a whole, while each child row describes an individual child object within the compound object.
+The children are connected to the parent through the "parentid" field, which contains a value matching the parent's "objectid" value.
+Ultimately all of the children will be displayed together on a single Item page.
+
+This approach allows each child object to be fully described individually (or not) using any field in your metadata.
+It is also useful if you are exporting existing metadata from a platform such as CONTENTdm with "page level" metadata.
 
 ### Metadata Conventions
 
-- The child record(s) must have a "parentid" that matches the "objectid" of their parent.
-- Both the parent and the child must have an "objectid".
-- The parent should have a "display_template" value of `compound_object` or `multiple` to use the respective display templates.
-- Child records should have their own "display_template" matching their media type to choose the appropriate features on the item page. (i.e. use `image` for a .JPG file)
-- The image listed in "image_thumb" and "image_small" of the parent will be used to represent the item in all visualizations.
+To include compound objects using the "compound_object" or "multiple" display_template (CB-CSV) or format (CB-GH), the following additional conventions are used in your metadata spreadsheet:
+
+- A "parentid" field must be added to your metadata spreadsheet. For non-compound object items, and parent items, the "parentid" field will be left blank.
+- The parent metadata record for each compound object will have an objectid (but no parentid), and use the display_template (CB-CSV) or format (CB-GH) value of either `compound_object` or `multiple`.  
+- Each child record **must have an objectid AND a parentid**
+    - Each child record's "parentid" value must match the parent metadata record's `objectid`. (e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.)
+    - Each child record should have a value for display_template (CB-CSV) or format (CB-GH) that corresponds to its media type. See [options for display_template]({{ '/docs/metadata/csv_metadata/#display_template' | relative_url }}) for CB-CSV and [options for format]({{ '/docs/metadata/gh_metadata/#format' | relative_url }}) for CB-GH. A parent with display_template/format `multiple` will have children with display_template (CB-CSV) value `image` or format (CB-GH) value `image/jpeg`. A parent with display_template/format `compound_object` could have children with a variety of display_template (CB-CSV) or format (CB-GH) values.
+
+**For CollectionBuilder-CSV only**: The image listed in "image_thumb" and "image_small" of the parent will be used to represent the item in all visualizations.
 
 ### Visualization Configuration Options
 
-You can use the Compound Objects options in "theme.yml" to configure if you would like the children of your compound objects to show up individually in the map, timeline, data, carousel, browse, and search pages.
-If the options are set to `true`, each child item will be individually represented on the page.
-If set to `false`, only the parent record (and its metadata) will appear (child objects will still be accessible on the parent's Item page). 
+Configure the "Compound Objects" options in "theme.yml" to add or remove the children of your compound objects on the map, timeline, data, carousel, browse, and search pages.
+
+If a Compound Objects option is set to `true`, each child item will be individually represented on the corresponding page.
+If set to `false`, only the parent record (and its metadata) will appear on the corresponding page.
+Child objects will still be accessible on the parent's Item page. 

--- a/docs/metadata/compound-objects.md
+++ b/docs/metadata/compound-objects.md
@@ -5,12 +5,11 @@ nav_order: 8
 ---
 # Compound Objects and Multiples
 
-{:.alert .alert-red }
-**Currently Compound Objects can only be used in CollectionBuilder-CSV.**
-
 _Note: While "object" is in the title of this section, a "compound object" is better categorized as an issue related to metadata than to objects (i.e. digital files) proper._
 
-Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://www.lib.uidaho.edu/collectionbuilder/collectionbuilder-csv-demo/) to see how this looks in operation. 
+Compound objects and multiples can be used in both CollectionBuilder-CSV and CollectionBuilder-GH, but the implementation process is slightly different between the two templates. 
+
+Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) for an example of how compound objects are represented in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) to see how this looks in operation. 
 
 ## Context
 
@@ -31,7 +30,7 @@ A `compound_object` can include a set of objects from any type of media that Col
 
 ### multiple
 
-A `multiple` is image based, and is best used for items such as postcards or multi-view records of a 3-dimensional object. 
+A `multiple` is image-based, and is best used for items such as postcards or multi-view records of a 3-dimensional object. 
 
 - Parent items with the display_template value of `multiple` will generate an Item page featuring the child items displayed as larger images. The children *do not* have child object pages / modals. Instead, clicking the child images will open a zoomable spotlight gallery of the images.
 - `multiple` Examples: 

--- a/docs/metadata/csv_metadata.md
+++ b/docs/metadata/csv_metadata.md
@@ -64,13 +64,13 @@ Setting the template enables a great deal of flexibility and simplifies customiz
 
 #### Compound Object Display Templates
 
-For normal items, each object is represented by one row in your metadata spreadsheet. 
+For regular items, each object is represented by one row in your metadata spreadsheet. 
 Compound objects on the other hand are represented by multiple rows: a parent row plus one or more child rows.
 The parent record describes the object overall, while each child describes the individual component parts/files--all of them will be displayed together on a single Item page.
 
 To include compound objects using the "compound_object" or "multiple" display template, the following additional conventions are used in your metadata spreadsheet:
 
-- A "parentid" field must be added to your metadata spreadsheet/csv. For normal items and parent items this field will left be blank.
+- A "parentid" field must be added to your metadata spreadsheet/csv. For regular items and parent items this field will left be blank.
 - The parent metadata record for each compound object will have an objectid (but no parentid), and use the "display_template" value of either `compound_object` or `multiple`.  
 - Each child record **must have an objectid AND a parentid**
     - Each child record's `parentid` value must match the parent metadata record's `objectid`. e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.

--- a/docs/metadata/csv_metadata.md
+++ b/docs/metadata/csv_metadata.md
@@ -56,29 +56,19 @@ Setting the template enables a great deal of flexibility and simplifies customiz
     - `panorama`: a 360 degree image. Item pages will use the Javascript based panorama viewer, [Panellum](https://pannellum.org/) to display the image in a 360 degree view.
     - `record`: metadata only record.
     - `item`: generic fallback item page, displays image or icon depending on "image_thumb"
-    - `compound_object`: a record for a object that includes multiple file instances that are described/managed separately in the metadata. The item page will display a grid of collected items (of any accepted CB type) whose metadata and media can be viewed in a series of browsable modals. Compound objects use an additional set of conventions, see [below for more details](#compound-object-display-templates). 
-    - `multiple`: a record for a object that includes multiple images (such as a postcard) that are listed separately in the metadata. The item page will feature a vertical series of large images that scroll down the page and a popup gallery function. Multiples use an additional set of conventions, see [below for more details](#compound-object-display-templates).
+    - `compound_object`: a record for an item that includes multiple file instances that are described/managed separately in the metadata. The item page will display a grid of collected items (of any accepted CB type) whose metadata and media can be viewed in a series of browsable modals. Compound objects use an additional set of conventions, see [below for more details](#compound-object-display-templates). 
+    - `multiple`: a record for an item that includes multiple images (such as a postcard) that are listed separately in the metadata. The item page will feature a vertical series of large images that scroll down the page and a popup gallery function. Multiples use an additional set of conventions, see [below for more details](#compound-object-display-templates).
 - See ["docs/item-pages.md"](https://github.com/CollectionBuilder/collectionbuilder-csv/blob/main/docs/item_pages.md) in your CollectionBuilder-CSV project repository for more details.
 
 <div class="alert alert-blue" markdown="1"> 
 
 #### Compound Object Display Templates
 
-For regular items, each object is represented by one row in your metadata spreadsheet. 
-Compound objects on the other hand are represented by multiple rows: a parent row plus one or more child rows.
-The parent record describes the object overall, while each child describes the individual component parts/files--all of them will be displayed together on a single Item page.
+CollectionBuilder-CSV supports Compound Objects!
+A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one connected item in the collection site and displayed on a single Item page. 
 
-To include compound objects using the "compound_object" or "multiple" display template, the following additional conventions are used in your metadata spreadsheet:
-
-- A "parentid" field must be added to your metadata spreadsheet/csv. For regular items and parent items this field will left be blank.
-- The parent metadata record for each compound object will have an objectid (but no parentid), and use the "display_template" value of either `compound_object` or `multiple`.  
-- Each child record **must have an objectid AND a parentid**
-    - Each child record's `parentid` value must match the parent metadata record's `objectid`. e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.
-    - Each child record can use any standard `display_template` corresponding to the object type. e.g. a parent using the `multiple` template will have several children using the `image` template; a parent using the `compound_object` template could have children using all different display template options.
-
-Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1UNwl02r3fB-ybiKqb3SY4K30Tf4_rY_NOv5_o5WtVoY/edit?usp=sharing) for an example of how this might look in a metadata spreadsheet, and visit the [demo CollectionBuilder-CSV site](https://compound-1lqv.onrender.com/) to see how this looks in operation. 
-
-For full details on compound objects, check out [our section on Compound Objects]({{ '/docs/metadata/compound-objects/' | relative_url }}).  
+Incorporating compound objects requires some additional conventions in your metadata spreadsheet.
+For full details on how to add compound objects to your site, check out the [Compound Objects section]({{ '/docs/metadata/compound-objects/' | relative_url }}) of the docs. 
 
 </div>
 

--- a/docs/metadata/csv_metadata.md
+++ b/docs/metadata/csv_metadata.md
@@ -68,7 +68,7 @@ CollectionBuilder-CSV supports Compound Objects!
 A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one connected item in the collection site and displayed on a single Item page. 
 
 Incorporating compound objects requires some additional conventions in your metadata spreadsheet.
-For full details on how to add compound objects to your site, check out the [Compound Objects section]({{ '/docs/metadata/compound-objects/' | relative_url }}) of the docs. 
+For full details on how to use the compound_object and multiple display templates, check out the [Compound Objects section]({{ '/docs/metadata/compound-objects/' | relative_url }}) of the docs. 
 
 </div>
 

--- a/docs/metadata/gh_metadata.md
+++ b/docs/metadata/gh_metadata.md
@@ -53,6 +53,29 @@ Without values in the fields below, CollectionBuilder will not work properly.
     - Audio: `audio/mp3`
     - Video: `video/mp4`
 
+<div class="alert alert-blue" markdown="1"> 
+
+#### Compound Object Formats
+
+For regular items, each object is represented by one row in your metadata spreadsheet. 
+Compound objects on the other hand are represented by multiple rows: a parent row plus one or more child rows.
+The parent record describes the object overall, while each child describes the individual component parts/files--all of them will be displayed together on a single Item page.
+
+To include compound objects using the "compound_object" or "multiple" format, the following additional conventions are used in your metadata spreadsheet:
+
+- A "parentid" field must be added to your metadata spreadsheet/csv. For regular items and parent items this field will left be blank.
+- The parent metadata record for each compound object will have an objectid (but no parentid), and use the "format" value of either `compound_object` or `multiple`.  
+- Each child record **must have an objectid AND a parentid**
+    - Each child record's `parentid` value must match the parent metadata record's `objectid`. e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.
+    - Each child record can use any standard "format" corresponding to the object format. e.g. a parent using the `multiple` format will have several children using the `image` format; a parent using the `compound_object` format could have children using all different format options.
+
+Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1C1ZV3VrawKRLYUtemUdi8hLbhJw2yhn6kv-xv6_HaNk/copy?usp=sharing) for an example of how this might look in a metadata spreadsheet, and visit the [demo CollectionBuilder-GH site](https://collectionbuilder.github.io/collectionbuilder-gh/) to see how this looks in operation. 
+
+For full details on compound objects, check out [our section on Compound Objects]({{ '/docs/metadata/compound-objects/' | relative_url }}).  
+
+</div>
+
+
 ### youtubeid (only required for YouTube video items):
 
 - This is the unique string assigned to a video when it is uploaded to YouTube. An easy way to find this is to look at the url for your YouTube video. The ID will be the string attached to the end of the url. For example, in "https://www.youtube.com/watch?v=sHhk1eAgopU" the youtubeid is `sHhk1eAgopU`.

--- a/docs/metadata/gh_metadata.md
+++ b/docs/metadata/gh_metadata.md
@@ -47,12 +47,14 @@ Without values in the fields below, CollectionBuilder will not work properly.
 
 ### format: 
 
-- This field indicates the item's media type. Since CollectionBuilder uses logic based on `format` to display objects, this is the most important field to ensure the interactive visualizations function correctly. If there are errors or anomalies, some pages will not work. The input for this field should be structured according to [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml){:target="_blank" rel="noopener"} standards, consisting of a type and a subtype concatenated with a slash (`/`) between them.
-    - Image: `image/jpeg`
+- This field indicates the item's media type. Since CollectionBuilder uses logic based on `format` to display objects, this is the most important field to ensure the interactive visualizations function correctly. If there are errors or anomalies, some pages will not work. The input for this field should be structured according to [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml){:target="_blank" rel="noopener"} standards, consisting of a type and a subtype concatenated with a slash (`/`) between them. Use the actual MIME type corresponding to your item's file, which can generally be inferred by looking at the file extension (e.g. ".jpg", ".pdf", etc).
+- Below are the common format values supported by CB-GH:
+    - Image: `image/jpeg`, `image/png`
     - Document: `application/pdf`
     - Audio: `audio/mp3`
     - Video: `video/mp4`
-    - Compound Object: `compound_object`
+- Two special format values are used to support "compound object" Item types:
+    - Compound Object: `compound_object` 
     - Multiple: `multiple`
 
 <div class="alert alert-blue" markdown="1"> 

--- a/docs/metadata/gh_metadata.md
+++ b/docs/metadata/gh_metadata.md
@@ -52,26 +52,18 @@ Without values in the fields below, CollectionBuilder will not work properly.
     - Document: `application/pdf`
     - Audio: `audio/mp3`
     - Video: `video/mp4`
+    - Compound Object: `compound_object`
+    - Multiple: `multiple`
 
 <div class="alert alert-blue" markdown="1"> 
 
 #### Compound Object Formats
 
-For regular items, each object is represented by one row in your metadata spreadsheet. 
-Compound objects on the other hand are represented by multiple rows: a parent row plus one or more child rows.
-The parent record describes the object overall, while each child describes the individual component parts/files--all of them will be displayed together on a single Item page.
+CollectionBuilder-GH supports Compound Objects!
+A "Compound Object" describes an item that is made up of a set of digital files intended to be treated as one connected item in the collection site and displayed on a single Item page. 
 
-To include compound objects using the "compound_object" or "multiple" format, the following additional conventions are used in your metadata spreadsheet:
-
-- A "parentid" field must be added to your metadata spreadsheet/csv. For regular items and parent items this field will left be blank.
-- The parent metadata record for each compound object will have an objectid (but no parentid), and use the "format" value of either `compound_object` or `multiple`.  
-- Each child record **must have an objectid AND a parentid**
-    - Each child record's `parentid` value must match the parent metadata record's `objectid`. e.g. If the parent's "objectid" is `example002`, then all children should have `example002` in their "parentid" field.
-    - Each child record can use any standard "format" corresponding to the object format. e.g. a parent using the `multiple` format will have several children using the `image` format; a parent using the `compound_object` format could have children using all different format options.
-
-Please see the [demo compound object metadata sheet](https://docs.google.com/spreadsheets/d/1C1ZV3VrawKRLYUtemUdi8hLbhJw2yhn6kv-xv6_HaNk/copy?usp=sharing) for an example of how this might look in a metadata spreadsheet, and visit the [demo CollectionBuilder-GH site](https://collectionbuilder.github.io/collectionbuilder-gh/) to see how this looks in operation. 
-
-For full details on compound objects, check out [our section on Compound Objects]({{ '/docs/metadata/compound-objects/' | relative_url }}).  
+Incorporating compound objects requires some additional conventions in your metadata spreadsheet.
+For full details on how to add compound objects to your site, check out the [Compound Objects section]({{ '/docs/metadata/compound-objects/' | relative_url }}) of the docs. 
 
 </div>
 


### PR DESCRIPTION
- Add docs for GH compound objects
- Move majority of compound object docs to "Compound Objects" page in metadata section
- Shorten compound objects alert on CSV and GH metadata pages