### PR TITLE
Browse options additions

### DIFF
--- a/_change-log/browse.md
+++ b/_change-log/browse.md
@@ -18,7 +18,7 @@ These features are controlled through new options in "_data/theme.yml":
 
 
 {:.alert .alert-red}
-**Note:** These options are only available on **CollectionBuilder-CSV** at the moment. Our **GH** and **SHEETS** templates currently only offer simle searching.
+**Note:** Enhanced browse features are currently only available in **CollectionBuilder-CSV**. GH and SHEETS templates continue to use simple search functionality.
 
 ## Template Integration Updates
 
@@ -34,8 +34,7 @@ The home page feature formerly called "Objects" (`{% include index/objects.html 
 
 Users preferring the simpler search functionality can disable the enhanced features by setting both `advanced-search` and `faceted-search` to `false` in theme.yml. The template will revert to the previous search behavior.
 
-{:.alert .alert-red}
-**Note:** Enhanced browse features are currently only available in **CollectionBuilder-CSV**. GH and SHEETS templates continue to use simple search functionality.
+
 
 These enhancements are documented in the [Browse Page theme options]({{ '/docs/theme/browse/' | relative_url }}) and [Browse Configuration]({{ '/docs/customization/config-browse/' | relative_url }}) sections.
 

--- a/_change-log/browse.md
+++ b/_change-log/browse.md
@@ -1,0 +1,41 @@
+---
+title: Browse Page Enhancements
+release: 2025-05-30
+---
+
+CollectionBuilder-CSV now supports enhanced browse functionality with new advanced search and filtering capabilities:
+
+## New Browse Features
+
+- **Advanced Search**: Users can now access detailed search options via a modal dialog by clicking the advanced search button above the search box. This allows for more complex search construction and filtering.
+- **Faceted Search**: A new field selection panel appears to the left of search results, enabling users to filter results by specific metadata fields configured in browse-config.csv.
+- **Default Sorting**: Collections can now specify a default sort field that determines the initial order when users first visit the Browse page.
+
+These features are controlled through new options in "_data/theme.yml":
+- `advanced-search: true/false`
+- `faceted-search: true/false` 
+- `default-sort-field: [field-name]`
+
+
+{:.alert .alert-red}
+**Note:** These options are only available on **CollectionBuilder-CSV** at the moment. Our **GH** and **SHEETS** templates currently only offer simle searching.
+
+## Template Integration Updates
+
+- **URL Filtering**: Browse page now supports dynamic filtering through URL parameters (e.g., `browse.html#subject:forests`)
+- **Word Cloud Links**: Links from word clouds now integrate with the new browse filtering system
+- **Item Page Links**: Subject and location links on item pages now properly filter browse results
+
+## Home Page Content Update
+
+The home page feature formerly called "Objects" (`{% include index/objects.html %}`) has been renamed to "Content" (`{% include index/content.html %}`) for better clarity. The functionality remains unchanged.
+
+## Backward Compatibility
+
+Users preferring the simpler search functionality can disable the enhanced features by setting both `advanced-search` and `faceted-search` to `false` in theme.yml. The template will revert to the previous search behavior.
+
+{:.alert .alert-red}
+**Note:** Enhanced browse features are currently only available in **CollectionBuilder-CSV**. GH and SHEETS templates continue to use simple search functionality.
+
+These enhancements are documented in the [Browse Page theme options]({{ '/docs/theme/browse/' | relative_url }}) and [Browse Configuration]({{ '/docs/customization/config-browse/' | relative_url }}) sections.
+

--- a/_change-log/browse.md
+++ b/_change-log/browse.md
@@ -8,7 +8,7 @@ CollectionBuilder-CSV now supports enhanced browse functionality with new advanc
 ## New Browse Features
 
 - **Advanced Search**: Users can now access detailed search options via a modal dialog by clicking the advanced search button above the search box. This allows for more complex search construction and filtering.
-- **Faceted Search**: A new field selection panel appears to the left of search results, enabling users to filter results by specific metadata fields configured in browse-config.csv.
+- **Faceted Search**: A new field selection panel appears to the left of search results, enabling users to filter results by specific metadata fields configured in config-browse.csv.
 - **Default Sorting**: Collections can now specify a default sort field that determines the initial order when users first visit the Browse page.
 
 These features are controlled through new options in "_data/theme.yml":

--- a/_change-log/browse.md
+++ b/_change-log/browse.md
@@ -28,7 +28,7 @@ These features are controlled through new options in "_data/theme.yml":
 
 ## Home Page Content Update
 
-The home page feature formerly called "Objects" (`{% include index/objects.html %}`) has been renamed to "Content" (`{% include index/content.html %}`) for better clarity. The functionality remains unchanged.
+The home page feature formerly called "Objects"  has been renamed to "Content" for better clarity and it's include snippet is now at `_includes/index/content.html` rather than `_includes/index/objects.html`. The functionality remains unchanged.
 
 ## Backward Compatibility
 

--- a/docs/customization/config-browse.md
+++ b/docs/customization/config-browse.md
@@ -8,41 +8,52 @@ nav_order: 3
 
 The Browse page displays each item in the collection as a "card," which is a design feature common to Bootstrap. 
 At the top of the page, a search box allows users to limit the display by searching for certain terms. 
-We also use subject links throughout the site that link back into the browse page and filter the collection based on the filter chosen. 
 
-So, for instance, if on the Subjects page, you clicked a button for "Forests," you would actually be clicking a link whose url ended as "browse.html#forests." 
-The Browse page would take anything after the hashtag (`#`) and filter the collection's cards by it. 
+{:.alert .alert-blue}
+**Note:** Additional Browse page features like advanced search, faceted search, and default sorting can be enabled in the "_data/theme.yml" file. These features rely on proper configuration of this file (config-browse.csv) to work effectively.
 
 The "_data/config-browse.csv" allows you to control which metadata appears on a card for each item. 
 Title appears on the card automatically. 
 After that, you can add whatever metadata you'd like to the CSV, as well as determine how that metadata will be displayed. 
 
-The columns are described below, and an [example](#example) is provided for your convenience:
+We also use subject links throughout the site that link back into the browse page and filter the collection based on the filter chosen. 
+So, for instance, if on the Subjects page, you clicked a button for "Forests," you would actually be clicking a link whose url ended as "browse.html#forests." 
+The Browse page would take anything after the hashtag (`#`) and filter the collection's cards by it. 
+
+## Configuration Columns
+
+The columns in config-browse.csv control both how metadata displays on cards and how search and sort functions work:
 
 ### field: 
 - Selects the field from your metadata CSV.
+- **Important:** Fields defined here are used by advanced search and faceted search features.
 
 ### display_name: 
 - Determines the field name as it is displayed to users.
+- This label appears on browse cards and in advanced search options.
 
 ### btn: 
 - Determines whether the field displays as a button. 
     - *Options*: `true` or leave blank
-    - `true` will turn all metadata in that field into buttons, and is recommend for fields that have multiple entries, like 'subject.' 
+    - `true` will turn all metadata in that field into buttons, and is recommended for fields that have multiple entries, like 'subject.'
+    - Button fields work especially well with faceted search filtering.
 
 ### hidden: 
 - Determines whether this field is hidden.
     - *Options*: `true` or leave blank
     - Useful when you don't want a metadata field to be visibly present on Browse page cards, but still want to filter for that field.
+    - Hidden fields are still searchable with advanced and faceted search.
 
 ### sort_name: 
 - Determines if the field will be used as an option to sort cards on the browse page via the dropdown menu to the right of the search box. This option also determines the label used in that dropdown menu for the field. 
     - *Options*: write whatever word/phrase you'd like to show up in the dropdown field. Once an option is entered, the sort function will work for that field.
     - Typically, you just put the display_name here, but oftentimes it's helpful to give more context, such as in the example below for Date, where the sort function indicates that it will sort by "Date Created"
+    - **Important:** To use a field as the default sort in theme.yml, you must include a sort_name for that field.
+
 
 ------
 
-### Example 
+## Example 
 
 ```
 field,display_name,btn,hidden,sort_name
@@ -52,8 +63,8 @@ creator,Creator,,,
 subject,,true
 location,,true
 identifier,,,true,Identifier
-
 ```
+
 
 ### Field and Display Names
 
@@ -66,11 +77,16 @@ The above example embodies this approach.
 
 If, using the above example, you wanted a user's browse page search to pull up items that include words in the description, but you don't want those descriptions making the cards too big, you could add the value `true` to the column titled "hidden". 
 
-### Sort Option
+## Using Sort Features
 
 The sort option appears as a dropdown menu next to the search box on the browse page. 
 You can also use the hidden option with a sort feature that allows you to sort the browse page items by any metadata variable. 
 In the above example, we include the identifier as part of the browse card, but we hide it while making it one of the search options. 
 Sorting by identifier allows a user to see the collection in its original order. 
 
-The sort option doesn't have to match the field name, so, again in the above example, we let the user sort by the `date` field, but we label that `Date Created` in the sort dropdown menu. 
+The sort option doesn't have to match the field name, so, again in the above example, we let the user sort by the `date` field, but we label that `Date Created` in the sort dropdown menu.
+
+If you want a specific sort order to be the default when users first visit the Browse page, you can set this in the theme.yml file with the `default-sort-field` option. The value must exactly match a field name from the first column of config-browse.csv.
+
+{:.alert .alert-blue}
+**Note:** Even hidden fields are included in advanced search and faceted search filtering, making them powerful tools for discovery while keeping your browse cards clean and readable.

--- a/docs/customization/config-browse.md
+++ b/docs/customization/config-browse.md
@@ -46,9 +46,7 @@ The columns are described below, and an [example](#example) is provided for your
 
 ### facet_name: 
 
-{:.alert .alert-red}
-**NOTE:** This option only applies to **CSV**. **GH** and **SHEETS** do not have faceted/advanced search options. 
-
+- **NOTE:** This option only applies to **CSV**. **GH** and **SHEETS** do not have faceted/advanced search options (yet). 
 - Determines the field name as it is displayed to users in the facet dropdown menus that appear both on the main page and via the advanced search modal.
 - The name will default to display_name if that is present so no need to define that twice if you already do it in that field.
     - Typically, the reason to use this column is when you're making one of your fields a button on the card but don't want to label it on the card, which means you don't enter a display_name -- in that case, you can still label how the field is displayed to a user in the faceted/advanced dropdowns by defining the label here
@@ -93,24 +91,3 @@ If you want a specific sort order to be the default when users first visit the B
 
 {:.alert .alert-blue}
 **Note:** Even hidden fields are included in advanced search and faceted search filtering.
-
-
-## How the Browse Page Works
-
-The Browse page has two main components:
-
-1. **Item Display**: Each collection item appears as a card showing metadata you configure
-2. **Search & Filter**: Users can search terms or use enhanced filtering options
-
-## Enhanced Browse Features
-
-{:.alert .alert-blue}
-**Note:** Additional Browse page features can be enabled in the "_data/theme.yml" file:
-- **Advanced Search**: Adds detailed search options via a modal dialog
-- **Faceted Search**: Provides filter dropdowns based on metadata fields  
-- **Default Sorting**: Sets initial sort order when page loads
-
-These enhanced features require proper configuration of the "config-browse.csv" file to work effectively.
-
-{:.alert .alert-green}
-**Simple Search Option**: To use the basic search functionality instead, set both `advanced-search` and `faceted-search` to `false` in theme.yml.

--- a/docs/customization/config-browse.md
+++ b/docs/customization/config-browse.md
@@ -45,6 +45,10 @@ The columns are described below, and an [example](#example) is provided for your
     - **Important:** To use a field as the default sort in theme.yml, you must include a sort_name for that field.
 
 ### facet_name: 
+
+{:.alert .alert-red}
+**NOTE:** This option only applies to **CSV**. **GH** and **SHEETS** do not have faceted/advanced search options. 
+
 - Determines the field name as it is displayed to users in the facet dropdown menus that appear both on the main page and via the advanced search modal.
 - The name will default to display_name if that is present so no need to define that twice if you already do it in that field.
     - Typically, the reason to use this column is when you're making one of your fields a button on the card but don't want to label it on the card, which means you don't enter a display_name -- in that case, you can still label how the field is displayed to a user in the faceted/advanced dropdowns by defining the label here

--- a/docs/customization/config-browse.md
+++ b/docs/customization/config-browse.md
@@ -6,31 +6,25 @@ nav_order: 3
 
 # Browse Page Configuration (config-browse.csv)
 
-The Browse page displays each item in the collection as a "card," which is a design feature common to Bootstrap. 
-At the top of the page, a search box allows users to limit the display by searching for certain terms. 
+The Browse page displays each item in your collection as a "card" - a Bootstrap design component that shows item information in an organized, visual format. At the top of the page, users can search and filter the collection using a search box.
 
-{:.alert .alert-blue}
-**Note:** Additional Browse page features like advanced search, faceted search, and default sorting can be enabled in the "_data/theme.yml" file. These features rely on proper configuration of this file (config-browse.csv) to work effectively.
+The "_data/config-browse.csv" file controls:
+- Which metadata fields appear on each item card
+- How that metadata is displayed (labels, buttons, hidden fields)
+- Which fields are available for searching and sorting
 
-The "_data/config-browse.csv" allows you to control which metadata appears on a card for each item. 
-Title appears on the card automatically. 
-After that, you can add whatever metadata you'd like to the CSV, as well as determine how that metadata will be displayed. 
 
-We also use subject links throughout the site that link back into the browse page and filter the collection based on the filter chosen. 
-So, for instance, if on the Subjects page, you clicked a button for "Forests," you would actually be clicking a link whose url ended as "browse.html#forests." 
-The Browse page would take anything after the hashtag (`#`) and filter the collection's cards by it. 
-
-## Configuration Columns
-
-The columns in config-browse.csv control both how metadata displays on cards and how search and sort functions work:
+The columns are described below, and an [example](#example) is provided for your convenience: 
 
 ### field: 
 - Selects the field from your metadata CSV.
 - **Important:** Fields defined here are used by advanced search and faceted search features.
+- **Default Behavior**: The item title automatically appears on every card. You configure all other metadata fields through the CSV.
+
 
 ### display_name: 
 - Determines the field name as it is displayed to users.
-- This label appears on browse cards and in advanced search options.
+- This label appears on browse cards and as advanced/faceted search options (if not defined by the `facet_name` field detailed below).
 
 ### btn: 
 - Determines whether the field displays as a button. 
@@ -42,7 +36,7 @@ The columns in config-browse.csv control both how metadata displays on cards and
 - Determines whether this field is hidden.
     - *Options*: `true` or leave blank
     - Useful when you don't want a metadata field to be visibly present on Browse page cards, but still want to filter for that field.
-    - Hidden fields are still searchable with advanced and faceted search.
+    - Hidden fields are still searchable with advanced and faceted search and will appear as options in the faceted/advanced dropdowns.
 
 ### sort_name: 
 - Determines if the field will be used as an option to sort cards on the browse page via the dropdown menu to the right of the search box. This option also determines the label used in that dropdown menu for the field. 
@@ -50,28 +44,33 @@ The columns in config-browse.csv control both how metadata displays on cards and
     - Typically, you just put the display_name here, but oftentimes it's helpful to give more context, such as in the example below for Date, where the sort function indicates that it will sort by "Date Created"
     - **Important:** To use a field as the default sort in theme.yml, you must include a sort_name for that field.
 
+### facet_name: 
+- Determines the field name as it is displayed to users in the facet dropdown menus that appear both on the main page and via the advanced search modal.
+- The name will default to display_name if that is present so no need to define that twice if you already do it in that field.
+    - Typically, the reason to use this column is when you're making one of your fields a button on the card but don't want to label it on the card, which means you don't enter a display_name -- in that case, you can still label how the field is displayed to a user in the faceted/advanced dropdowns by defining the label here
 
 ------
 
 ## Example 
 
 ```
-field,display_name,btn,hidden,sort_name
+field,display_name,btn,hidden,sort_name,facet_name
 date,Date,,,Date Created
 description,,,,
 creator,Creator,,,
 subject,,true
-location,,true
+location,,true,,,Location Depicted
 identifier,,,true,Identifier
 ```
 
 
 ### Field and Display Names
 
-If you want to add a description to the browse cards, and label it "Description" on the user interface, you would include a value of `description` in the "field" column and then include `Description` as the value of that row's "displayName" column.
+If you want to add a description to the browse cards, and label it "Description" on the user interface, you would include a value of `description` in the "field" column and then include `Description` as the value of that row's "display_name" column.
 
 If you want to include items' descriptions on the browse cards but feel that including the label, "Description" is unnecessary, you could include a value of `description` in the "field" column and then leave that row's "display_name" column blank. 
-The above example embodies this approach.
+
+The above example embodies this approach. Note that the description field will be listed in the advanced/faceted dropdown menus as "Description" since the code defaults to the capitalized field name when neither the display_name or facet_name fields are present.
 
 ### Hiding Metadata (so sneaky!) 
 
@@ -89,4 +88,25 @@ The sort option doesn't have to match the field name, so, again in the above exa
 If you want a specific sort order to be the default when users first visit the Browse page, you can set this in the theme.yml file with the `default-sort-field` option. The value must exactly match a field name from the first column of config-browse.csv.
 
 {:.alert .alert-blue}
-**Note:** Even hidden fields are included in advanced search and faceted search filtering, making them powerful tools for discovery while keeping your browse cards clean and readable.
+**Note:** Even hidden fields are included in advanced search and faceted search filtering.
+
+
+## How the Browse Page Works
+
+The Browse page has two main components:
+
+1. **Item Display**: Each collection item appears as a card showing metadata you configure
+2. **Search & Filter**: Users can search terms or use enhanced filtering options
+
+## Enhanced Browse Features
+
+{:.alert .alert-blue}
+**Note:** Additional Browse page features can be enabled in the "_data/theme.yml" file:
+- **Advanced Search**: Adds detailed search options via a modal dialog
+- **Faceted Search**: Provides filter dropdowns based on metadata fields  
+- **Default Sorting**: Sets initial sort order when page loads
+
+These enhanced features require proper configuration of the "config-browse.csv" file to work effectively.
+
+{:.alert .alert-green}
+**Simple Search Option**: To use the basic search functionality instead, set both `advanced-search` and `faceted-search` to `false` in theme.yml.

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -45,7 +45,7 @@ This is what the default "home-infographic.html" layout looks like:
 
 {% include index/featured-terms.html field="location" title="Locations" btn-color="outline-secondary" %}
 
-{% include index/objects.html %}
+{% include index/content.html %}
 
 </div>
 <div class="col-md-12">
@@ -160,7 +160,7 @@ Here's an example where there is one big top carousel, then three separate secti
 </div>
 <div class="col-md-4">
 
-{% include index/objects.html %}
+{% include index/content.html %}
 
 </div>
 

--- a/docs/theme/advanced.md
+++ b/docs/theme/advanced.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Options
 parent: Theme Options
-nav_order: 11
+nav_order: 12
 ---
 
 # Advanced Theme Options

--- a/docs/theme/browse.md
+++ b/docs/theme/browse.md
@@ -8,6 +8,16 @@ nav_order: 2
 
 This section of "_data/theme.yml" configures your collection's Browse page features.
 
+## Browse Page Filtering
+
+The Browse page supports dynamic filtering through URL parameters. For example:
+- Clicking "Forests" on the Subjects page creates a link ending with `browse.html#subject:forests`
+- The Browse page reads this URL fragment (`#subject:forests`)
+- It splits this into field (`subject`) and value (`forests`)
+- Then filters the displayed cards to only show items with "forests" as a subject
+
+This filtering system works with any metadata field configured in your config-browse.csv file.
+
 ## Browse Page Options:
 
 ### advanced-search:
@@ -36,6 +46,11 @@ faceted-search: true
 faceted-search: false
 ```
 
+{:.alert .alert-yellow}
+**Simple Search Option:** The below options enable advanced/faceted search options. To use the basic search functionality instead, set both `advanced-search` and `faceted-search` to `false` in theme.yml.
+
+
+
 ### default-sort-field:
 
 - Determines which metadata field is used for the default sorting of browse results.
@@ -46,8 +61,9 @@ default-sort-field: date
 ```
 - If left blank or if the value doesn't match any field in browse-config.csv's first column, the default sort will be a random sort.
 
+
 {:.alert .alert-blue}
-**Note:** The Browse page's display fields are configured in "_data/browse-config.csv". This file defines which metadata fields will be displayed and how they'll appear in the browse view.
+**Note:** The Browse page's display fields are configured in "_data/browse-config.csv". This file defines which metadata fields will be displayed and how they'll appear in the browse view. [More Here]({{'/docs/customization/config-browse/' | relative_url }})
 
 {:.alert .alert-green}
 **Pro Tip**: When configuring your Browse page, consider what fields are most important for your users to search and filter by. Including too many facets can be overwhelming, while too few might limit discovery.

--- a/docs/theme/browse.md
+++ b/docs/theme/browse.md
@@ -8,18 +8,8 @@ nav_order: 2
 
 This section of "_data/theme.yml" configures your collection's Browse page features.
 
-## Browse Page Filtering
-
-The Browse page supports dynamic filtering through URL parameters. For example:
-- Clicking "Forests" on the Subjects page creates a link ending with `browse.html#subject:forests`
-- The Browse page reads this URL fragment (`#subject:forests`)
-- It splits this into field (`subject`) and value (`forests`)
-- Then filters the displayed cards to only show items with "forests" as a subject
-
-This filtering system works with any metadata field configured in your config-browse.csv file.
-
-{:.alert .alert-red}
-**Note:** These options are only available on **CollectionBuilder-CSV** at the moment. Our **GH** and **SHEETS** templates currently only offer simle searching.
+{:.alert .alert-blue}
+**NOTE:** The options described below only apply to **CSV**. **GH** and **SHEETS** do not have faceted/advanced search options or default sort (yet).
 
 ## Browse Page Options:
 

--- a/docs/theme/browse.md
+++ b/docs/theme/browse.md
@@ -1,0 +1,53 @@
+---
+title: Browse Page
+parent: Theme Options
+nav_order: 2
+---
+
+# Browse Page
+
+This section of "_data/theme.yml" configures your collection's Browse page features.
+
+## Browse Page Options:
+
+### advanced-search:
+
+- This option enables or disables the advanced search functionality.
+- When enabled, users can access advanced search options by clicking the advanced search button above the search box. This opens a modal in which more complex searches can be constructed.
+- It can be either:
+```yaml
+advanced-search: true
+```
+- or:
+```yaml
+advanced-search: false
+```
+
+### faceted-search:
+
+- This option enables or disables faceted search functionality.
+- When enabled, a field selection panel appears to the left of the search results, allowing users to filter results by specific metadata fields.
+- It can be either:
+```yaml
+faceted-search: true
+```
+- or:
+```yaml
+faceted-search: false
+```
+
+### default-sort-field:
+
+- Determines which metadata field is used for the default sorting of browse results.
+- The value must match one of the field values (first column) in the browse-config.csv file.
+- For example:
+```yaml
+default-sort-field: date
+```
+- If left blank or if the value doesn't match any field in browse-config.csv's first column, the default sort will be a random sort.
+
+{:.alert .alert-blue}
+**Note:** The Browse page's display fields are configured in "_data/browse-config.csv". This file defines which metadata fields will be displayed and how they'll appear in the browse view.
+
+{:.alert .alert-green}
+**Pro Tip**: When configuring your Browse page, consider what fields are most important for your users to search and filter by. Including too many facets can be overwhelming, while too few might limit discovery.

--- a/docs/theme/browse.md
+++ b/docs/theme/browse.md
@@ -47,12 +47,12 @@ faceted-search: false
 ### default-sort-field:
 
 - Determines which metadata field is used for the default sorting of browse results.
-- The value must match one of the field values (first column) in the browse-config.csv file.
+- The value must match one of the field values (first column) in the config-browse.csv file.
 - For example:
 ```yaml
 default-sort-field: date
 ```
-- If left blank or if the value doesn't match any field in browse-config.csv's first column, the default sort will be a random sort.
+- If left blank or if the value doesn't match any field in config-browse.csv's first column, the default sort will be a random sort.
 
 
 {:.alert .alert-blue}

--- a/docs/theme/browse.md
+++ b/docs/theme/browse.md
@@ -18,6 +18,9 @@ The Browse page supports dynamic filtering through URL parameters. For example:
 
 This filtering system works with any metadata field configured in your config-browse.csv file.
 
+{:.alert .alert-red}
+**Note:** These options are only available on **CollectionBuilder-CSV** at the moment. Our **GH** and **SHEETS** templates currently only offer simle searching.
+
 ## Browse Page Options:
 
 ### advanced-search:

--- a/docs/theme/compound.md
+++ b/docs/theme/compound.md
@@ -1,7 +1,7 @@
 ---
 title: Compound Objects
 parent: Theme Options
-nav_order: 10
+nav_order: 11
 ---
 
 # Compound Objects

--- a/docs/theme/data.md
+++ b/docs/theme/data.md
@@ -1,7 +1,7 @@
 ---
 title: Data
 parent: Theme Options
-nav_order: 9
+nav_order: 10
 ---
 
 # Data 

--- a/docs/theme/index.md
+++ b/docs/theme/index.md
@@ -1,7 +1,7 @@
 ---
 title: Theme Options
 has_children: true
-nav_order: 7
+nav_order: 8
 ---
 
 # Theme Configuration Options

--- a/docs/theme/item.md
+++ b/docs/theme/item.md
@@ -1,7 +1,7 @@
 ---
 title: Item Page
 parent: Theme Options
-nav_order: 4
+nav_order: 5
 ---
 
 # Item Page 

--- a/docs/theme/locations.md
+++ b/docs/theme/locations.md
@@ -1,7 +1,7 @@
 ---
 title: Locations Page
 parent: Theme Options
-nav_order: 6
+nav_order: 7
 ---
 
 # Locations Page

--- a/docs/theme/map.md
+++ b/docs/theme/map.md
@@ -1,7 +1,7 @@
 ---
 title: Map Page
 parent: Theme Options
-nav_order: 7
+nav_order: 8
 ---
 
 # Map Page

--- a/docs/theme/subjects.md
+++ b/docs/theme/subjects.md
@@ -1,7 +1,7 @@
 ---
 title: Subjects Page
 parent: Theme Options
-nav_order: 5
+nav_order: 6
 ---
 
 # Subjects Page

--- a/docs/theme/timeline.md
+++ b/docs/theme/timeline.md
@@ -1,7 +1,7 @@
 ---
 title: Timeline Page
 parent: Theme Options
-nav_order: 8
+nav_order: 9
 ---
 
 # Timeline Page


### PR DESCRIPTION
Basically adding new pages for browse options to better define everything and changing the index/objects.html include to index/content.html

cool!



This pull request focuses on enhancing documentation for configuration files and reorganizing navigation order within the theme options documentation. Key updates include expanded descriptions for Browse page functionalities, changes to home page layout references, and adjustments to navigation order across multiple theme pages.

### Documentation Enhancements for Browse Page:

* [`docs/customization/config-browse.md`](diffhunk://#diff-48c94f5c86c759c1eb8f6f1e5a32fdcbbc46edb7f6bdfde4c07248f40d2f9a18L9-R112): Expanded descriptions for metadata configuration in `config-browse.csv`, including new fields like `facet_name` and detailed explanations of sorting and filtering options. Added notes on advanced and faceted search features.
* [`docs/theme/browse.md`](diffhunk://#diff-2193d693d266c21518bf4dba3bc7a78f90e7412b345394e712cc8828bce5542bR1-R69): Added a new page detailing Browse page options in `theme.yml`, including advanced search, faceted search, and default sort field configurations.

### Home Page Layout Updates:

* [`docs/pages/home.md`](diffhunk://#diff-b30a1eddb13fc316c457ca2e72cbc97d8de88b385053a9323cf052900e05e978L48-R48): Replaced the `index/objects.html` include with `index/content.html` in multiple sections to update the default home page layout references. [[1]](diffhunk://#diff-b30a1eddb13fc316c457ca2e72cbc97d8de88b385053a9323cf052900e05e978L48-R48) [[2]](diffhunk://#diff-b30a1eddb13fc316c457ca2e72cbc97d8de88b385053a9323cf052900e05e978L163-R163)

### Navigation Order Adjustments:

* Updated `nav_order` for multiple theme pages to reorganize their display order in the documentation hierarchy:
  - [`docs/theme/advanced.md`](diffhunk://#diff-d8e19830d214948cfe4271d7cb2ba9b2e334630a9ae2364534338f42c366a685L4-R4): Changed `nav_order` from 11 to 12.
  - [`docs/theme/compound.md`](diffhunk://#diff-584a2034969effef5fee71cbac867eb38ab539e27f47fbf477772032a94927dfL4-R4): Changed `nav_order` from 10 to 11.
  - [`docs/theme/data.md`](diffhunk://#diff-52dc8c1dfc198fe7702a72251feb084f142befb292d3eb22490ad61c774dbd5eL4-R4): Changed `nav_order` from 9 to 10.
  - [`docs/theme/index.md`](diffhunk://#diff-d9dca656e71d43b41a54ad0e304e1f544f9015af61816a2ea94b7a71541c35feL4-R4): Changed `nav_order` from 7 to 8.
  - [`docs/theme/item.md`](diffhunk://#diff-54c23c26b4ab8ebe3629e7cbdb99262b18be32a2869b2cb35b5c4fc375d2d0d4L4-R4): Changed `nav_order` from 4 to 5.
  - [`docs/theme/locations.md`](diffhunk://#diff-1c5444ebe4e34089a233410d38e66cb2c95ac0fa5dbba0e4c562669bc3e04d5bL4-R4): Changed `nav_order` from 6 to 7.
  - [`docs/theme/map.md`](diffhunk://#diff-071e2ccf6694889b831a4ebd7d1a78160812edaec1b742ddba7cdf8f73e19110L4-R4): Changed `nav_order` from 7 to 8.
  - [`docs/theme/subjects.md`](diffhunk://#diff-f767f4d3ffef517e48b103cc743e392bd7e75e7c153b2fcb93b2b6f48ec1ee2dL4-R4): Changed `nav_order` from 5 to 6.
  - [`docs/theme/timeline.md`](diffhunk://#diff-7fd22de1714fe9650c94a25cf4c419ecacbee65698d84467d49d00dddfc5d433L4-R4): Changed `nav_order` from 8 to 9.